### PR TITLE
Use path.join for file paths, fixes pkg support

### DIFF
--- a/src/linebreaker.coffee
+++ b/src/linebreaker.coffee
@@ -1,10 +1,12 @@
 UnicodeTrie = require 'unicode-trie'
 fs = require 'fs'
+path = require 'path'
 base64 = require 'base64-js'
 {BK, CR, LF, NL, CB, BA, SP, WJ, SP, BK, LF, NL, AI, AL, SA, SG, XX, CJ, ID, NS, characterClasses} = require './classes'
 {DI_BRK, IN_BRK, CI_BRK, CP_BRK, PR_BRK, pairTable} = require './pairs'
 
-data = base64.toByteArray fs.readFileSync __dirname + '/classes.trie', 'base64'
+dataPath = path.join __dirname, 'classes.trie'
+data = base64.toByteArray fs.readFileSync dataPath, 'base64'
 classTrie = new UnicodeTrie data
 
 class LineBreaker

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,4 +1,5 @@
 fs = require 'fs'
+path = require 'path'
 punycode = require 'punycode'
 LineBreaker = require '../'
 assert = require 'assert'
@@ -16,7 +17,8 @@ describe 'unicode line break tests', ->
           4850, 4851, 4852, 4854, 4855, 4856, 4858, 4859, 4960, 4962, 5036, 5038, 6126, 6135, 6140, 6225,
           6226, 6227, 6228, 6229, 6230, 6232, 6233, 6234, 6235, 6236, 6332]
   
-  data = fs.readFileSync __dirname + '/LineBreakTest.txt', 'utf8'
+  dataPath = path.join __dirname, 'LineBreakTest.txt'
+  data = fs.readFileSync dataPath, 'utf8'
   lines = data.split '\n'  
 
   lines.forEach (line, i) ->


### PR DESCRIPTION
Using path.join allows pkg to bundle files into the binary, otherwise the binary crashes trying to load the classes.trie file. Found while trying to use pdfmake on our server.