### PR TITLE
Upgrade brfs to version 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/devongovett/linebreaker",
   "dependencies": {
     "base64-js": "0.0.8",
-    "brfs": "^1.3.0",
+    "brfs": "^2.0.2",
     "unicode-trie": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Updates `package.json` to use `brfs` version `2.0.2` instead of `1.3.0` since `brfs` has been updated to fix [vulnerability](https://github.com/browserify/static-eval/commit/32f8efd072625e267aa7237d2daff35738c50d2a).

@blikblum @devongovett