### PR TITLE
More removing coffeescript references in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,8 +48,8 @@ while (bk = breaker.nextBreak()) {
 In order to use the library, you shouldn't need to know this, but if you're interested in
 contributing or fixing bugs, these things might be of interest.
 
-* The `src/classes.coffee` file is automatically generated from `LineBreak.txt` in the Unicode 
-  database by `src/generate_data.coffee`. It should be rare that you need to run this, but
+* The `src/classes.js` file is automatically generated from `LineBreak.txt` in the Unicode 
+  database by `src/generate_data.js`. It should be rare that you need to run this, but
   you may if, for instance, you want to change the Unicode version.
   
 * You can run the tests using `npm test`. They are written using `mocha`, and generated from


### PR DESCRIPTION
Couple of file extensions in `readme.md` were overlooked - minor issue.