### PR TITLE
Add browser friendly build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 node_modules/
+/src/linebreaker-browser.js

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "homepage": "https://github.com/devongovett/linebreaker",
   "dependencies": {
     "base64-js": "1.3.1",
-    "brfs": "^2.0.2",
     "unicode-trie": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "^6.0.2",
+    "quote-stream": "^1.0.2",
     "request": "^2.88.0",
     "static-module": "^3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -24,15 +24,14 @@
   },
   "devDependencies": {
     "mocha": "^6.0.2",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "static-module": "^3.0.3"
   },
   "scripts": {
+    "build": "node tools/build",
+    "prepublishOnly": "npm run build",
     "test": "mocha"
   },
-  "main": "src/linebreaker",
-  "browserify": {
-    "transform": [
-      "brfs"
-    ]
-  }
+  "main": "src/linebreaker.js",
+  "browser": "src/linebreaker-browser.js"
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "node tools/build",
     "prepublishOnly": "npm run build",
-    "test": "mocha"
+    "test": "npm run build && mocha"
   },
   "main": "src/linebreaker.js",
   "browser": "src/linebreaker-browser.js"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/devongovett/linebreaker",
   "dependencies": {
-    "base64-js": "0.0.8",
+    "base64-js": "1.3.1",
     "brfs": "^2.0.2",
     "unicode-trie": "^1.0.0"
   },

--- a/src/linebreaker.js
+++ b/src/linebreaker.js
@@ -1,10 +1,9 @@
 const UnicodeTrie = require('unicode-trie');
 const fs = require('fs');
-const base64 = require('base64-js');
 const { BK, CR, LF, NL, SG, WJ, CB, SP, BA, NS, AI, AL, CJ, ID, SA, XX } = require('./classes');
 const { DI_BRK, IN_BRK, CI_BRK, CP_BRK, PR_BRK, pairTable } = require('./pairs');
 
-const data = base64.toByteArray(fs.readFileSync(__dirname + '/classes.trie', 'base64'));
+const data = fs.readFileSync(__dirname + '/classes.trie');
 const classTrie = new UnicodeTrie(data);
 
 const mapClass = function (c) {

--- a/src/linebreaker.js
+++ b/src/linebreaker.js
@@ -4,6 +4,7 @@ const { BK, CR, LF, NL, SG, WJ, CB, SP, BA, NS, AI, AL, CJ, ID, SA, XX } = requi
 const { DI_BRK, IN_BRK, CI_BRK, CP_BRK, PR_BRK, pairTable } = require('./pairs');
 
 const data = fs.readFileSync(__dirname + '/classes.trie');
+
 const classTrie = new UnicodeTrie(data);
 
 const mapClass = function (c) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const punycode = require('punycode');
-const LineBreaker = require('../');
+const LineBreakerNode = require('../src/linebreaker');
+const LineBreakerBrowser = require('../src/linebreaker-browser');
 const assert = require('assert');
 
-describe('unicode line break tests', function () {
+function runTests(LineBreaker) {
   // these tests are weird, possibly incorrect or just tailored differently. we skip them.
   const skip = [812,   814,  848,  850,  864,  866,  900,  902,  956,  958, 1068, 1070, 1072, 1074, 1224, 1226,
           1228, 1230, 1760, 1762, 2932, 2934, 4100, 4101, 4102, 4103, 4340, 4342, 4496, 4498, 4568, 4570,
@@ -49,4 +50,12 @@ describe('unicode line break tests', function () {
 
     it(cols, () => assert.deepEqual(breaks, expected, i + ' ' + JSON.stringify(breaks) + ' != ' + JSON.stringify(expected) + ' #' + comment));
   });
+}
+
+describe('node - unicode line break tests', function () {
+  runTests(LineBreakerNode);
+});
+
+describe('browser - unicode line break tests', function () {
+  runTests(LineBreakerBrowser);
 });

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,0 +1,31 @@
+var staticModule = require('static-module');
+var quote = require('quote-stream');
+var through = require('through2');
+var fs = require('fs');
+
+function write (buf, enc, next) {
+  this.push(buf);
+  next();
+}
+
+function end (next) {
+  this.push(')');
+  this.push(null);
+  next();
+}
+
+var sm = staticModule({
+    fs: {
+        readFileSync: function (file) {
+          const stream = fs.createReadStream(file, 'base64').pipe(quote()).pipe(through(write, end));
+          stream.push('base64.toByteArray(')
+          return stream;
+        }
+    }
+}, { vars: { __dirname: __dirname + '/../src' } });
+
+const src = fs.createReadStream('src/linebreaker.js');
+const dest = fs.createWriteStream('src/linebreaker-browser.js');
+
+src.push('const base64 = require(\'base64-js\');\n');
+src.pipe(sm).pipe(dest);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,7 +1243,7 @@ static-eval@^2.0.2:
   dependencies:
     escodegen "^1.8.1"
 
-static-module@^3.0.2:
+static-module@^3.0.2, static-module@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/static-module/-/static-module-3.0.3.tgz#cc2301ed3fe353e2d2a2195137013853676f9960"
   integrity sha512-RDaMYaI5o/ym0GkCqL/PlD1Pn216omp8fY81okxZ6f6JQxWW5tptOw9reXoZX85yt/scYvbWIt6uoszeyf+/MQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,16 +128,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brfs@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brfs/-/brfs-2.0.2.tgz#44237878fa82aa479ce4f5fe2c1796ec69f07845"
-  integrity sha512-IrFjVtwu4eTJZyu8w/V2gxU7iLTtcHih67sgEdzrhjLBMHp2uYefUBfdM4k2UvcuWMgV7PQDZHSLeNWnLFKWVQ==
-  dependencies:
-    quote-stream "^1.0.1"
-    resolve "^1.1.5"
-    static-module "^3.0.2"
-    through2 "^2.0.0"
-
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
@@ -1034,11 +1024,6 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -1082,7 +1067,7 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-quote-stream@^1.0.1:
+quote-stream@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/quote-stream/-/quote-stream-1.0.2.tgz#84963f8c9c26b942e153feeb53aae74652b7e0b2"
   integrity sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=
@@ -1144,13 +1129,6 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-resolve@^1.1.5:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
-  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
-  dependencies:
-    path-parse "^1.0.6"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -1243,7 +1221,7 @@ static-eval@^2.0.2:
   dependencies:
     escodegen "^1.8.1"
 
-static-module@^3.0.2, static-module@^3.0.3:
+static-module@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/static-module/-/static-module-3.0.3.tgz#cc2301ed3fe353e2d2a2195137013853676f9960"
   integrity sha512-RDaMYaI5o/ym0GkCqL/PlD1Pn216omp8fY81okxZ6f6JQxWW5tptOw9reXoZX85yt/scYvbWIt6uoszeyf+/MQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,10 +108,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
-  integrity sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=
+base64-js@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
This adds a browser build that does not depends on node "fs" module, so no need to run brfs when targeting browser environments

It also benefits node users with memory reduction since removes base64-js dependency and no intermediary base64 encoded data is loaded into memory

A "browser" entry is added to package.json and tests are adapted to run with both builds