### PR TITLE
Move "import" above "require" in `exports` conditionals

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "main": "dist/main.cjs",
   "module": "dist/module.mjs",
   "exports": {
-    "require": "./dist/main.cjs",
-    "import": "./dist/module.mjs"
+    "import": "./dist/module.mjs",
+    "require": "./dist/main.cjs"
   },
   "files": [
     "dist"


### PR DESCRIPTION
According to the Node.js [docs page for conditional exports](https://nodejs.org/api/packages.html#conditional-exports), the key order of the fields in the `exports` object is significant:

> Within the ["exports"](https://nodejs.org/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries. The general rule is that conditions should be from most specific to least specific in object order.

And right above that, it's listed that `import` is more specific than `require`, so this PR swaps the order of those two keys such that bundlers would pick the `import` entry when both conditions are acceptable.